### PR TITLE
Switch HomeController to use repository interface

### DIFF
--- a/Presentation/Esce.Api/Controllers/HomeController.cs
+++ b/Presentation/Esce.Api/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿using Esce.Persistence.Repositories;
+using Esce.Application.Interface.Repository;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,11 +8,11 @@ namespace Esce.Api.Controllers
     [ApiController]
     public class HomeController : ControllerBase
     {
-        private readonly ProductRepository _productRepository;
+        private readonly IProductRepository _productRepository;
 
-        public HomeController(ProductRepository productRepository)
+        public HomeController(IProductRepository productRepository)
         {
-            _productRepository=productRepository;
+            _productRepository = productRepository;
         }
         [HttpGet]
         public IActionResult GelProducts()


### PR DESCRIPTION
## Summary
- use `IProductRepository` field and constructor in `HomeController`
- add interface namespace for `HomeController`

## Testing
- `dotnet build Esce.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684016c7fc90832685021358ef96be73